### PR TITLE
Support for additional control schemes

### DIFF
--- a/src/main/java/frc/robot/commands/TeleopArmCommand.java
+++ b/src/main/java/frc/robot/commands/TeleopArmCommand.java
@@ -1,94 +1,25 @@
 package frc.robot.commands;
 
-import java.util.Optional;
 import java.util.function.Supplier;
 
-import edu.wpi.first.math.filter.SlewRateLimiter;
 import edu.wpi.first.wpilibj2.command.CommandBase;
 import frc.robot.input.MoInput;
 import frc.robot.subsystems.ArmSubsystem;
-import frc.robot.subsystems.ArmSubsystem.ArmMovementRequest;
-import frc.robot.subsystems.ArmSubsystem.ArmPosition;
-import frc.robot.utils.ArmSetpointManager;
-import frc.robot.utils.MoPrefs;
-import frc.robot.utils.ArmSetpointManager.ArmSetpoint;
-import frc.robot.utils.MoPrefs.Pref;
 
 public class TeleopArmCommand extends CommandBase {
     private final ArmSubsystem arms;
     private final Supplier<MoInput> inputSupplier;
 
-    private Pref<Double> rampTime = MoPrefs.armRampTime;
-
-    private ArmSetpoint lastSetpoint = ArmSetpoint.STOW;
-    private boolean smartMotionPositionOverride = false;
-
-    private SlewRateLimiter shoulderLimiter;
-    private SlewRateLimiter wristLimiter;
-
     public TeleopArmCommand(ArmSubsystem arms, Supplier<MoInput> inputSupplier) {
         this.arms = arms;
         this.inputSupplier = inputSupplier;
 
-        rampTime.subscribe(rampTime -> {
-            double slewRate = 1.0 / rampTime;
-
-            shoulderLimiter = new SlewRateLimiter(slewRate);
-            wristLimiter = new SlewRateLimiter(slewRate);
-        }, true);
-
         addRequirements(arms);
-    }
-
-    private ArmMovementRequest getLimitedMovementRequest(MoInput input) {
-        ArmMovementRequest requestedMovement = input.getArmMovementRequest();
-        return new ArmMovementRequest(
-            shoulderLimiter.calculate(requestedMovement.shoulderPower),
-            wristLimiter.calculate(requestedMovement.wristPower)
-        );
-    }
-
-    private void smartMotion(MoInput input) {
-        Optional<ArmSetpoint> requestedSetpoint = input.getRequestedArmSetpoint();
-        ArmMovementRequest requestedMovement = getLimitedMovementRequest(input);
-        boolean shouldSaveSetpoint = input.getSaveArmSetpoint();
-
-        if(requestedSetpoint.isPresent()) {
-            if(shouldSaveSetpoint) {
-                ArmSetpointManager.getInstance().setSetpoint(lastSetpoint, arms.getPosition());
-            } else {
-                smartMotionPositionOverride = false;
-                lastSetpoint = requestedSetpoint.get();
-            }
-        }
-
-        if(!requestedMovement.isZero()) {
-            smartMotionPositionOverride = true;
-        }
-
-        ArmPosition requestedPosition = ArmSetpointManager.getInstance().getSetpoint(lastSetpoint);
-        if(smartMotionPositionOverride) {
-            arms.adjustVelocity(requestedMovement);
-        } else {
-            arms.adjustSmartPosition(requestedPosition);
-        }
     }
 
     @Override
     public void execute() {
         MoInput input = inputSupplier.get();
-        var controlMode = arms.armChooser.getSelected();
-        switch(controlMode) {
-            case FALLBACK_DIRECT_POWER:
-                arms.adjustDirectPower(getLimitedMovementRequest(input));
-            return;
-            case DIRECT_VELOCITY:
-                arms.adjustVelocity(getLimitedMovementRequest(input));
-            return;
-            case SMART_MOTION:
-                this.smartMotion(input);
-            return;
-        }
+        arms.armChooser.getSelected().apply(input, this.arms);;
     }
-
 }

--- a/src/main/java/frc/robot/commands/auto/HoldArmPositionCommand.java
+++ b/src/main/java/frc/robot/commands/auto/HoldArmPositionCommand.java
@@ -5,8 +5,8 @@ import java.util.Map;
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj2.command.CommandBase;
 import frc.robot.subsystems.ArmSubsystem;
-import frc.robot.subsystems.ArmSubsystem.ArmControlMode;
 import frc.robot.subsystems.ArmSubsystem.ArmPosition;
+import frc.robot.utils.ArmControlMode;
 import frc.robot.utils.ArmSetpointManager;
 import frc.robot.utils.ArmSetpointManager.ArmSetpoint;
 
@@ -27,7 +27,7 @@ public class HoldArmPositionCommand extends CommandBase {
     @Override
     public void execute() {
         ArmControlMode mode = arms.armChooser.getSelected();
-        if(mode != ArmControlMode.SMART_MOTION) {
+        if(!mode.allowsAutonomousSmartMotion()) {
             DriverStation.reportWarning("Attempt to autonomously move arms when SmartMotion is disabled", false);
             arms.stop();
             return;

--- a/src/main/java/frc/robot/input/DualControllerInput.java
+++ b/src/main/java/frc/robot/input/DualControllerInput.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import edu.wpi.first.wpilibj.XboxController;
 import frc.robot.Constants;
 import frc.robot.subsystems.ArmSubsystem.ArmMovementRequest;
+import frc.robot.subsystems.ArmSubsystem.ArmPosition;
 import frc.robot.utils.MoPrefs;
 import frc.robot.utils.ArmSetpointManager.ArmSetpoint;
 import frc.robot.utils.MoPrefs.Pref;
@@ -64,7 +65,7 @@ public class DualControllerInput implements MoInput {
     }
 
     @Override
-    public ArmMovementRequest getArmMovementRequest() {
+    public ArmMovementRequest getDirectArmMovementRequest() {
         return new ArmMovementRequest(
             applyArmInputTransforms(armController.getLeftY()),
             applyArmInputTransforms(armController.getRightY())
@@ -72,7 +73,7 @@ public class DualControllerInput implements MoInput {
     }
 
     @Override
-    public Optional<ArmSetpoint> getRequestedArmSetpoint() {
+    public Optional<ArmSetpoint> getFineControlArmSetpoint() {
         double pov = armController.getPOV();
         boolean cubes = armController.getXButton();
         boolean cones = armController.getAButton();
@@ -114,4 +115,29 @@ public class DualControllerInput implements MoInput {
         return armController.getStartButton();
     }
 
+    @Override
+    public ArmPosition getCraneControlArmMovementRequest() {
+        return new ArmPosition(this.armController.getLeftTriggerAxis(), this.armController.getRightTriggerAxis());
+    }
+
+    @Override
+    public Optional<ArmSetpoint> getCraneControlArmSetpoint() {
+        // Duplicate of single controller, could be improved to take advantage of the whole controller
+        if (this.armController.getAButton()) {
+            return Optional.of(ArmSetpoint.CONE_LOW);
+        }
+        if (this.armController.getXButton()) {
+            return Optional.of(ArmSetpoint.CONE_MED);
+        }
+        if (this.armController.getYButton()) {
+            return Optional.of(ArmSetpoint.CONE_HIGH);
+        }
+        if (this.getShouldIntake()) {
+            return Optional.of(ArmSetpoint.CONE_PICKUP);
+        }
+        if (this.getShouldExhaust()) {
+            return Optional.of(ArmSetpoint.CUBE_PICKUP);
+        }
+        return Optional.empty();
+    }
 }

--- a/src/main/java/frc/robot/input/MoInput.java
+++ b/src/main/java/frc/robot/input/MoInput.java
@@ -3,6 +3,7 @@ package frc.robot.input;
 import java.util.Optional;
 
 import frc.robot.subsystems.ArmSubsystem.ArmMovementRequest;
+import frc.robot.subsystems.ArmSubsystem.ArmPosition;
 import frc.robot.utils.ArmSetpointManager.ArmSetpoint;
 
 public interface MoInput {
@@ -14,8 +15,10 @@ public interface MoInput {
     public boolean getShouldIntake();
     public boolean getShouldExhaust();
 
-    public ArmMovementRequest getArmMovementRequest();
+    public ArmMovementRequest getDirectArmMovementRequest();
+    public ArmPosition getCraneControlArmMovementRequest();
 
-    public Optional<ArmSetpoint> getRequestedArmSetpoint();
+    public Optional<ArmSetpoint> getFineControlArmSetpoint();
+    public Optional<ArmSetpoint> getCraneControlArmSetpoint();
     public boolean getSaveArmSetpoint();
 }

--- a/src/main/java/frc/robot/input/SingleControllerInput.java
+++ b/src/main/java/frc/robot/input/SingleControllerInput.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 import edu.wpi.first.wpilibj.XboxController;
 import frc.robot.Constants;
 import frc.robot.subsystems.ArmSubsystem.ArmMovementRequest;
+import frc.robot.subsystems.ArmSubsystem.ArmPosition;
 import frc.robot.utils.MoPrefs;
 import frc.robot.utils.ArmSetpointManager.ArmSetpoint;
 import frc.robot.utils.MoPrefs.Pref;
@@ -55,8 +56,13 @@ public class SingleControllerInput implements MoInput {
     }
 
     @Override
-    public ArmMovementRequest getArmMovementRequest() {
+    public ArmMovementRequest getDirectArmMovementRequest() {
         return new ArmMovementRequest(getDirectShoulderRequest(), getDirectWristRequest());
+    }
+
+    @Override
+    public ArmPosition getCraneControlArmMovementRequest() {
+        return new ArmPosition(this.controller.getRightTriggerAxis(), this.controller.getLeftTriggerAxis());
     }
 
     @Override
@@ -70,7 +76,7 @@ public class SingleControllerInput implements MoInput {
     }
 
     @Override
-    public Optional<ArmSetpoint> getRequestedArmSetpoint() {
+    public Optional<ArmSetpoint> getFineControlArmSetpoint() {
         double pov = this.controller.getPOV();
         boolean cubes = this.controller.getXButton();
         boolean cones = this.controller.getAButton();
@@ -109,5 +115,25 @@ public class SingleControllerInput implements MoInput {
     @Override
     public boolean getSaveArmSetpoint() {
         return controller.getStartButton();
+    }
+
+    @Override
+    public Optional<ArmSetpoint> getCraneControlArmSetpoint() {
+        if (this.controller.getAButton()) {
+            return Optional.of(ArmSetpoint.CONE_LOW);
+        }
+        if (this.controller.getXButton()) {
+            return Optional.of(ArmSetpoint.CONE_MED);
+        }
+        if (this.controller.getYButton()) {
+            return Optional.of(ArmSetpoint.CONE_HIGH);
+        }
+        if (this.getShouldIntake()) {
+            return Optional.of(ArmSetpoint.CONE_PICKUP);
+        }
+        if (this.getShouldExhaust()) {
+            return Optional.of(ArmSetpoint.CUBE_PICKUP);
+        }
+        return Optional.empty();
     }
 }

--- a/src/main/java/frc/robot/utils/ArmControlMode.java
+++ b/src/main/java/frc/robot/utils/ArmControlMode.java
@@ -1,0 +1,137 @@
+package frc.robot.utils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import frc.robot.input.MoInput;
+import frc.robot.subsystems.ArmSubsystem;
+import frc.robot.subsystems.ArmSubsystem.ArmMovementRequest;
+import frc.robot.subsystems.ArmSubsystem.ArmPosition;
+import frc.robot.utils.ArmSetpointManager.ArmSetpoint;
+
+public abstract class ArmControlMode implements Nameable {
+    public static final List<ArmControlMode> ALL_CONTROL_TYPES = new ArrayList<>();
+    public final String name;
+
+    protected ArmControlMode(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String getName() {
+        return this.name;
+    }
+
+    public abstract void apply(MoInput input, ArmSubsystem arms);
+
+    public boolean allowsAutonomousSmartMotion() {
+        return false;
+    }
+
+    static {
+        ALL_CONTROL_TYPES.add(new DirectPower());
+        ALL_CONTROL_TYPES.add(new DirectVelocity());
+        ALL_CONTROL_TYPES.add(new FineControlSmartMotion());
+        ALL_CONTROL_TYPES.add(new CraneSmartMotion());
+    }
+
+    public static class DirectPower extends ArmControlMode {
+        public DirectPower() {
+            super("Direct Power (Fallback)");
+        }
+
+        @Override
+        public void apply(MoInput input, ArmSubsystem arms) {
+            arms.adjustDirectPower(arms.limitedMovementOf(input.getDirectArmMovementRequest()));
+        }
+    }
+
+    public static class DirectVelocity extends ArmControlMode {
+        public DirectVelocity() {
+            super("Direct Velocity");
+        }
+
+        @Override
+        public void apply(MoInput input, ArmSubsystem arms) {
+            arms.adjustVelocity(arms.limitedMovementOf(input.getDirectArmMovementRequest()));
+        }
+    }
+
+    public static class FineControlSmartMotion extends ArmControlMode {
+        private ArmSetpoint lastSetpoint = ArmSetpoint.STOW;
+        private boolean smartMotionPositionOverride = false;
+
+        public FineControlSmartMotion() {
+            super("Fine-Control Smart Motion");
+        }
+
+        @Override
+        public void apply(MoInput input, ArmSubsystem arms) {
+            Optional<ArmSetpoint> requestedSetpoint = input.getFineControlArmSetpoint();
+            ArmMovementRequest requestedMovement = arms.limitedMovementOf(input.getDirectArmMovementRequest());
+            boolean shouldSaveSetpoint = input.getSaveArmSetpoint();
+
+            if(requestedSetpoint.isPresent()) {
+                if(shouldSaveSetpoint) {
+                    ArmSetpointManager.getInstance().setSetpoint(lastSetpoint, arms.getPosition());
+                } else {
+                    smartMotionPositionOverride = false;
+                    lastSetpoint = requestedSetpoint.get();
+                }
+            }
+
+            if(!requestedMovement.isZero()) {
+                smartMotionPositionOverride = true;
+            }
+
+            ArmPosition requestedPosition = ArmSetpointManager.getInstance().getSetpoint(lastSetpoint);
+            if(smartMotionPositionOverride) {
+                arms.adjustVelocity(requestedMovement);
+            } else {
+                arms.adjustSmartPosition(requestedPosition);
+            }
+        }
+
+        @Override
+        public boolean allowsAutonomousSmartMotion() {
+            return true;
+        }
+    }
+
+    public static class CraneSmartMotion extends ArmControlMode {
+        private ArmSetpoint lastSetpoint = ArmSetpoint.STOW;
+
+        public CraneSmartMotion() {
+            super("Crane Smart Motion");
+        }
+
+        @Override
+        public void apply(MoInput input, ArmSubsystem arms) {
+            Optional<ArmSetpoint> setpoint = input.getCraneControlArmSetpoint();
+            ArmPosition posMultiplier = input.getCraneControlArmMovementRequest();
+
+            boolean shouldSaveSetpoint = input.getSaveArmSetpoint();
+
+            if (setpoint.isPresent()) {
+                if (shouldSaveSetpoint) {
+                    ArmSetpointManager.getInstance().setSetpoint(lastSetpoint, arms.getPosition());
+                } else {
+                    lastSetpoint = setpoint.get();
+                }
+            }
+
+            ArmPosition requestedPosition = ArmSetpointManager.getInstance().getSetpoint(lastSetpoint);
+            requestedPosition = new ArmPosition(
+                requestedPosition.shoulderRotations * posMultiplier.shoulderRotations,
+                requestedPosition.wristRotations * posMultiplier.wristRotations);
+
+            arms.adjustSmartPosition(requestedPosition);
+        }
+
+        @Override
+        public boolean allowsAutonomousSmartMotion() {
+            return true;
+        }
+    }
+}

--- a/src/main/java/frc/robot/utils/MoShuffleboard.java
+++ b/src/main/java/frc/robot/utils/MoShuffleboard.java
@@ -1,5 +1,7 @@
 package frc.robot.utils;
 
+import java.util.List;
+
 import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
 import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
 import edu.wpi.first.wpilibj.smartdashboard.Field2d;
@@ -43,4 +45,17 @@ public class MoShuffleboard {
         return chooser;
     }
 
+    public static <T extends Nameable> SendableChooser<T> listToChooser(List<T> toConvert) {
+        boolean setDefault = true;
+        var chooser = new SendableChooser<T>();
+        for(T entry : toConvert) {
+            if(setDefault) {
+                chooser.setDefaultOption(entry.getName(), entry);
+                setDefault = false;
+            } else {
+                chooser.addOption(entry.getName(), entry);
+            }
+        }
+        return chooser;
+    }
 }

--- a/src/main/java/frc/robot/utils/Nameable.java
+++ b/src/main/java/frc/robot/utils/Nameable.java
@@ -1,0 +1,5 @@
+package frc.robot.utils;
+
+public interface Nameable {
+    String getName();
+}


### PR DESCRIPTION
- ArmControlMode is its own file, and is no longer an enum
- Subclasses of ArmControlMode define control modes for the arm, rather than being hardcoded into the arm command
- Slew rate limiters are stored by the ArmSubsystem rather than the command
- As before, though, slew rate limiting must be manually applied to ArmMovementRequests before they are passed to the ArmSubsystem